### PR TITLE
Update main.py

### DIFF
--- a/mirrorselect/main.py
+++ b/mirrorselect/main.py
@@ -104,7 +104,7 @@ class MirrorSelect:
 
         for i in range(0, len(hosts)):
             if isinstance(hosts[i], bytes):
-                hosts[i] = hosts[i].decode("utf-8")
+                hosts[i] = hosts[i].decode("utf-8", errors="replace")
 
         if var == "sync-uri" and out:
             mirror_string = "{} = {}".format(var, " ".join(hosts))


### PR DESCRIPTION
Fixes UnicodeDecodeError in mirrorselect by decoding with errors='replace'



`❯ mirrorselect -s10 -o

* Using url: https://api.gentoo.org/mirrors/distfiles.xml
* Downloading a list of mirrors...
 Got 240 mirrors.
* Using netselect to choose the top 10 mirrors...Done.
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.12/mirrorselect", line 55, in <module>
    MirrorSelect().main(sys.argv)
  File "/usr/lib/python3.12/site-packages/mirrorselect/main.py", line 469, in main
    self.change_config(
  File "/usr/lib/python3.12/site-packages/mirrorselect/main.py", line 107, in change_config
    hosts[i] = hosts[i].decode("utf-8")
               ^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf3 in position 42: invalid continuation byte`